### PR TITLE
feat: implement color theme picker and update layout for theme suppor…

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,20 +21,28 @@
 ## Features
 
 - **Auth** — Google OAuth and email/password sign-in via Supabase Auth
-- **Recipe management** — Create, view, edit, and delete recipes with title, description, ingredients, tags, and cook time
+- **Recipe management** — Create, view, edit, and delete recipes with title, description, ingredients, tags, cook time, and serving size
 - **Image upload** — Attach photos to recipes, stored in Supabase Storage
-- **Meal planning** — Plan weekly meals by assigning recipes to specific days and meal slots
-- **Shopping list** — Auto-generate organized shopping lists from meal plans with export capability
+- **Recipe filtering** — Filter recipes by ingredient, tag, and cook time
+- **Ingredient scaling** — Adjust serving count and have ingredient quantities scale automatically
+- **Nutritional info** — Ingredients are enriched via the USDA FoodData Central API on save; calories and macros are shown on recipe detail pages
+- **Print view** — Clean printer-friendly recipe layout with a Print / Save as PDF button
+- **Public recipes & discovery** — Mark recipes as public to generate a shareable link; browse all public recipes on the Discover page
+- **Social** — Like and comment on public recipes; authors can moderate comments on their own recipes
+- **Meal planning** — Plan weekly meals by assigning recipes to days and meal slots (Breakfast / Lunch / Dinner / Snacks), with a weekly nutritional summary
+- **Shopping list** — Auto-generate shopping lists from meal plans, grouped by grocery aisle, with mark-as-bought and CSV export
+- **PWA** — Installable as a progressive web app; shopping list works offline
+- **Color themes** — Choose from 8 pastel color themes; preference is persisted across sessions
 - **Monorepo** — `pnpm` workspaces with `apps/frontend` (Next.js) and `packages/shared`
 - **Quality gates** — Husky pre-commit hooks, lint-staged, branch/commit message validation, and GitHub Actions CI (lint, type-check, tests, coverage upload)
-- **Test coverage** — Vitest unit tests with ≥ 70% coverage enforced on every PR, uploaded to codecov
+- **Test coverage** — Vitest unit tests with ≥ 80% coverage enforced on every PR, uploaded to Codecov
 
 ## Quick start
 
 ### Prerequisites
 
 - Node.js 20+
-- pnpm 9+
+- pnpm 10+
 - Docker (for local Supabase)
 - [Supabase CLI](https://github.com/supabase/cli/releases) (`~/.supabase/supabase.exe` on Windows)
 

--- a/apps/frontend/e2e/theme-picker.spec.ts
+++ b/apps/frontend/e2e/theme-picker.spec.ts
@@ -1,0 +1,69 @@
+import { test, expect } from '@playwright/test';
+import { ensureAuthenticated } from './helpers/auth';
+
+test.describe('Color theme picker', () => {
+  test.beforeEach(async ({ page }) => {
+    await ensureAuthenticated(page);
+    await page.evaluate(() => localStorage.removeItem('color-theme'));
+    await page.goto('/recipes');
+  });
+
+  test('Color theme button is visible in the sidebar', async ({ page }) => {
+    await expect(page.getByRole('button', { name: 'Pick color theme' })).toBeVisible();
+  });
+
+  test('clicking the button reveals all 8 swatches', async ({ page }) => {
+    await page.getByRole('button', { name: 'Pick color theme' }).click();
+
+    for (const label of ['Sage', 'Rose', 'Lavender', 'Peach', 'Sky', 'Teal', 'Amber', 'Sand']) {
+      await expect(page.getByRole('button', { name: label })).toBeVisible();
+    }
+  });
+
+  test('selecting a theme applies its class to <html>', async ({ page }) => {
+    await page.getByRole('button', { name: 'Pick color theme' }).click();
+    await page.getByRole('button', { name: 'Rose' }).click();
+
+    const hasClass = await page.evaluate(() =>
+      document.documentElement.classList.contains('theme-rose'),
+    );
+    expect(hasClass).toBe(true);
+  });
+
+  test('selected theme persists after reload', async ({ page }) => {
+    await page.getByRole('button', { name: 'Pick color theme' }).click();
+    await page.getByRole('button', { name: 'Teal' }).click();
+
+    await page.reload();
+
+    const hasClass = await page.evaluate(() =>
+      document.documentElement.classList.contains('theme-teal'),
+    );
+    expect(hasClass).toBe(true);
+  });
+
+  test('switching theme removes the previous theme class', async ({ page }) => {
+    await page.getByRole('button', { name: 'Pick color theme' }).click();
+    await page.getByRole('button', { name: 'Rose' }).click();
+
+    await page.getByRole('button', { name: 'Pick color theme' }).click();
+    await page.getByRole('button', { name: 'Sky' }).click();
+
+    const classList = await page.evaluate(() => document.documentElement.className);
+    expect(classList).not.toContain('theme-rose');
+    expect(classList).toContain('theme-sky');
+  });
+
+  test('selecting Sage removes all theme classes', async ({ page }) => {
+    // First apply a non-default theme
+    await page.getByRole('button', { name: 'Pick color theme' }).click();
+    await page.getByRole('button', { name: 'Lavender' }).click();
+
+    // Switch back to Sage
+    await page.getByRole('button', { name: 'Pick color theme' }).click();
+    await page.getByRole('button', { name: 'Sage' }).click();
+
+    const classList = await page.evaluate(() => document.documentElement.className);
+    expect(classList).not.toContain('theme-');
+  });
+});

--- a/apps/frontend/src/app/globals.css
+++ b/apps/frontend/src/app/globals.css
@@ -60,6 +60,258 @@
   --ring: 142 45% 55%;
 }
 
+/* ── Rose ──────────────────────────────────────────────────────────────── */
+.theme-rose {
+  --background: 345 40% 97%;
+  --foreground: 345 45% 12%;
+  --card: 0 0% 100%;
+  --card-foreground: 345 45% 12%;
+  --primary: 345 55% 35%;
+  --primary-foreground: 0 0% 100%;
+  --secondary: 345 28% 92%;
+  --secondary-foreground: 345 45% 12%;
+  --muted: 345 22% 93%;
+  --muted-foreground: 345 18% 40%;
+  --accent: 345 33% 88%;
+  --accent-foreground: 345 45% 12%;
+  --border: 345 22% 88%;
+  --input: 345 22% 88%;
+  --ring: 345 55% 35%;
+}
+.dark.theme-rose {
+  --background: 345 28% 8%;
+  --foreground: 345 33% 93%;
+  --card: 345 23% 13%;
+  --card-foreground: 345 33% 93%;
+  --primary: 345 55% 65%;
+  --primary-foreground: 345 28% 8%;
+  --secondary: 345 18% 20%;
+  --secondary-foreground: 345 33% 93%;
+  --muted: 345 18% 20%;
+  --muted-foreground: 345 18% 62%;
+  --accent: 345 22% 22%;
+  --accent-foreground: 345 33% 93%;
+  --border: 345 16% 22%;
+  --input: 345 16% 22%;
+  --ring: 345 55% 65%;
+}
+
+/* ── Lavender ──────────────────────────────────────────────────────────── */
+.theme-lavender {
+  --background: 270 40% 97%;
+  --foreground: 270 45% 12%;
+  --card: 0 0% 100%;
+  --card-foreground: 270 45% 12%;
+  --primary: 270 50% 38%;
+  --primary-foreground: 0 0% 100%;
+  --secondary: 270 28% 92%;
+  --secondary-foreground: 270 45% 12%;
+  --muted: 270 22% 93%;
+  --muted-foreground: 270 18% 40%;
+  --accent: 270 33% 88%;
+  --accent-foreground: 270 45% 12%;
+  --border: 270 22% 88%;
+  --input: 270 22% 88%;
+  --ring: 270 50% 38%;
+}
+.dark.theme-lavender {
+  --background: 270 28% 8%;
+  --foreground: 270 33% 93%;
+  --card: 270 23% 13%;
+  --card-foreground: 270 33% 93%;
+  --primary: 270 50% 65%;
+  --primary-foreground: 270 28% 8%;
+  --secondary: 270 18% 20%;
+  --secondary-foreground: 270 33% 93%;
+  --muted: 270 18% 20%;
+  --muted-foreground: 270 18% 62%;
+  --accent: 270 22% 22%;
+  --accent-foreground: 270 33% 93%;
+  --border: 270 16% 22%;
+  --input: 270 16% 22%;
+  --ring: 270 50% 65%;
+}
+
+/* ── Peach ─────────────────────────────────────────────────────────────── */
+.theme-peach {
+  --background: 20 40% 97%;
+  --foreground: 20 45% 12%;
+  --card: 0 0% 100%;
+  --card-foreground: 20 45% 12%;
+  --primary: 20 65% 38%;
+  --primary-foreground: 0 0% 100%;
+  --secondary: 20 28% 92%;
+  --secondary-foreground: 20 45% 12%;
+  --muted: 20 22% 93%;
+  --muted-foreground: 20 18% 40%;
+  --accent: 20 33% 88%;
+  --accent-foreground: 20 45% 12%;
+  --border: 20 22% 88%;
+  --input: 20 22% 88%;
+  --ring: 20 65% 38%;
+}
+.dark.theme-peach {
+  --background: 20 28% 8%;
+  --foreground: 20 33% 93%;
+  --card: 20 23% 13%;
+  --card-foreground: 20 33% 93%;
+  --primary: 20 65% 65%;
+  --primary-foreground: 20 28% 8%;
+  --secondary: 20 18% 20%;
+  --secondary-foreground: 20 33% 93%;
+  --muted: 20 18% 20%;
+  --muted-foreground: 20 18% 62%;
+  --accent: 20 22% 22%;
+  --accent-foreground: 20 33% 93%;
+  --border: 20 16% 22%;
+  --input: 20 16% 22%;
+  --ring: 20 65% 65%;
+}
+
+/* ── Sky ───────────────────────────────────────────────────────────────── */
+.theme-sky {
+  --background: 205 40% 97%;
+  --foreground: 205 45% 12%;
+  --card: 0 0% 100%;
+  --card-foreground: 205 45% 12%;
+  --primary: 205 60% 32%;
+  --primary-foreground: 0 0% 100%;
+  --secondary: 205 28% 92%;
+  --secondary-foreground: 205 45% 12%;
+  --muted: 205 22% 93%;
+  --muted-foreground: 205 18% 40%;
+  --accent: 205 33% 88%;
+  --accent-foreground: 205 45% 12%;
+  --border: 205 22% 88%;
+  --input: 205 22% 88%;
+  --ring: 205 60% 32%;
+}
+.dark.theme-sky {
+  --background: 205 28% 8%;
+  --foreground: 205 33% 93%;
+  --card: 205 23% 13%;
+  --card-foreground: 205 33% 93%;
+  --primary: 205 60% 62%;
+  --primary-foreground: 205 28% 8%;
+  --secondary: 205 18% 20%;
+  --secondary-foreground: 205 33% 93%;
+  --muted: 205 18% 20%;
+  --muted-foreground: 205 18% 62%;
+  --accent: 205 22% 22%;
+  --accent-foreground: 205 33% 93%;
+  --border: 205 16% 22%;
+  --input: 205 16% 22%;
+  --ring: 205 60% 62%;
+}
+
+/* ── Teal ──────────────────────────────────────────────────────────────── */
+.theme-teal {
+  --background: 175 40% 97%;
+  --foreground: 175 45% 12%;
+  --card: 0 0% 100%;
+  --card-foreground: 175 45% 12%;
+  --primary: 175 55% 30%;
+  --primary-foreground: 0 0% 100%;
+  --secondary: 175 28% 92%;
+  --secondary-foreground: 175 45% 12%;
+  --muted: 175 22% 93%;
+  --muted-foreground: 175 18% 40%;
+  --accent: 175 33% 88%;
+  --accent-foreground: 175 45% 12%;
+  --border: 175 22% 88%;
+  --input: 175 22% 88%;
+  --ring: 175 55% 30%;
+}
+.dark.theme-teal {
+  --background: 175 28% 8%;
+  --foreground: 175 33% 93%;
+  --card: 175 23% 13%;
+  --card-foreground: 175 33% 93%;
+  --primary: 175 55% 58%;
+  --primary-foreground: 175 28% 8%;
+  --secondary: 175 18% 20%;
+  --secondary-foreground: 175 33% 93%;
+  --muted: 175 18% 20%;
+  --muted-foreground: 175 18% 62%;
+  --accent: 175 22% 22%;
+  --accent-foreground: 175 33% 93%;
+  --border: 175 16% 22%;
+  --input: 175 16% 22%;
+  --ring: 175 55% 58%;
+}
+
+/* ── Amber ─────────────────────────────────────────────────────────────── */
+.theme-amber {
+  --background: 42 40% 97%;
+  --foreground: 42 45% 12%;
+  --card: 0 0% 100%;
+  --card-foreground: 42 45% 12%;
+  --primary: 42 70% 35%;
+  --primary-foreground: 0 0% 100%;
+  --secondary: 42 28% 92%;
+  --secondary-foreground: 42 45% 12%;
+  --muted: 42 22% 93%;
+  --muted-foreground: 42 18% 40%;
+  --accent: 42 33% 88%;
+  --accent-foreground: 42 45% 12%;
+  --border: 42 22% 88%;
+  --input: 42 22% 88%;
+  --ring: 42 70% 35%;
+}
+.dark.theme-amber {
+  --background: 42 28% 8%;
+  --foreground: 42 33% 93%;
+  --card: 42 23% 13%;
+  --card-foreground: 42 33% 93%;
+  --primary: 42 70% 62%;
+  --primary-foreground: 42 28% 8%;
+  --secondary: 42 18% 20%;
+  --secondary-foreground: 42 33% 93%;
+  --muted: 42 18% 20%;
+  --muted-foreground: 42 18% 62%;
+  --accent: 42 22% 22%;
+  --accent-foreground: 42 33% 93%;
+  --border: 42 16% 22%;
+  --input: 42 16% 22%;
+  --ring: 42 70% 62%;
+}
+
+/* ── Sand ──────────────────────────────────────────────────────────────── */
+.theme-sand {
+  --background: 35 20% 97%;
+  --foreground: 35 25% 12%;
+  --card: 0 0% 100%;
+  --card-foreground: 35 25% 12%;
+  --primary: 35 30% 38%;
+  --primary-foreground: 0 0% 100%;
+  --secondary: 35 15% 92%;
+  --secondary-foreground: 35 25% 12%;
+  --muted: 35 12% 93%;
+  --muted-foreground: 35 10% 40%;
+  --accent: 35 18% 88%;
+  --accent-foreground: 35 25% 12%;
+  --border: 35 12% 88%;
+  --input: 35 12% 88%;
+  --ring: 35 30% 38%;
+}
+.dark.theme-sand {
+  --background: 35 18% 8%;
+  --foreground: 35 20% 93%;
+  --card: 35 15% 13%;
+  --card-foreground: 35 20% 93%;
+  --primary: 35 32% 58%;
+  --primary-foreground: 35 18% 8%;
+  --secondary: 35 12% 20%;
+  --secondary-foreground: 35 20% 93%;
+  --muted: 35 12% 20%;
+  --muted-foreground: 35 10% 62%;
+  --accent: 35 14% 22%;
+  --accent-foreground: 35 20% 93%;
+  --border: 35 10% 22%;
+  --input: 35 10% 22%;
+  --ring: 35 32% 58%;
+}
+
 /* Visible keyboard focus indicator using the design-system ring colour */
 :focus-visible {
   outline: 2px solid hsl(var(--ring));

--- a/apps/frontend/src/app/layout.tsx
+++ b/apps/frontend/src/app/layout.tsx
@@ -17,7 +17,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       <head>
         <script
           dangerouslySetInnerHTML={{
-            __html: `(function(){try{var t=localStorage.getItem('theme');if(t==='dark'||(!t&&window.matchMedia('(prefers-color-scheme: dark)').matches)){document.documentElement.classList.add('dark')}}catch(e){}})()`,
+            __html: `(function(){try{var t=localStorage.getItem('theme');if(t==='dark'||(!t&&window.matchMedia('(prefers-color-scheme: dark)').matches)){document.documentElement.classList.add('dark')}var c=localStorage.getItem('color-theme');if(c&&c!=='sage'){document.documentElement.classList.add('theme-'+c)}}catch(e){}})()`,
           }}
         />
       </head>

--- a/apps/frontend/src/components/app-sidebar.tsx
+++ b/apps/frontend/src/components/app-sidebar.tsx
@@ -4,6 +4,7 @@ import Image from 'next/image';
 import Link from 'next/link';
 import { useEffect, useRef, useState } from 'react';
 import { ThemeToggle } from '@/components/theme-toggle';
+import { ThemePicker } from '@/components/theme-picker';
 
 const NAV = [
   { href: '/recipes', label: 'Recipes', icon: '🍳' },
@@ -70,6 +71,7 @@ export function AppSidebar() {
         {/* Bottom controls */}
         <div className="flex flex-col gap-1 border-t border-border p-2">
           <ThemeToggle showLabel />
+          <ThemePicker />
           <a
             href="/auth/logout"
             className="flex w-full items-center gap-3 rounded-md px-3 py-2 text-sm text-muted-foreground transition-colors hover:bg-accent/50 hover:text-accent-foreground"
@@ -133,6 +135,7 @@ export function AppSidebar() {
                   ))}
                   <div className="mt-2 border-t border-border pt-2">
                     <ThemeToggle showLabel />
+                    <ThemePicker />
                     <a
                       href="/auth/logout"
                       className="flex items-center gap-3 rounded-md px-3 py-2 text-sm text-muted-foreground hover:bg-accent/50 hover:text-accent-foreground"

--- a/apps/frontend/src/components/theme-picker.tsx
+++ b/apps/frontend/src/components/theme-picker.tsx
@@ -1,0 +1,111 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+
+const THEMES = [
+  { id: 'sage', label: 'Sage', color: 'hsl(142 55% 38%)' },
+  { id: 'rose', label: 'Rose', color: 'hsl(345 55% 52%)' },
+  { id: 'lavender', label: 'Lavender', color: 'hsl(270 50% 55%)' },
+  { id: 'peach', label: 'Peach', color: 'hsl(20 65% 58%)' },
+  { id: 'sky', label: 'Sky', color: 'hsl(205 60% 52%)' },
+  { id: 'teal', label: 'Teal', color: 'hsl(175 55% 38%)' },
+  { id: 'amber', label: 'Amber', color: 'hsl(42 70% 50%)' },
+  { id: 'sand', label: 'Sand', color: 'hsl(35 30% 52%)' },
+] as const;
+
+type ThemeId = (typeof THEMES)[number]['id'];
+
+function applyColorTheme(id: ThemeId) {
+  const el = document.documentElement;
+  THEMES.forEach((t) => {
+    if (t.id !== 'sage') el.classList.remove(`theme-${t.id}`);
+  });
+  if (id !== 'sage') el.classList.add(`theme-${id}`);
+  localStorage.setItem('color-theme', id);
+}
+
+export function ThemePicker() {
+  const [colorTheme, setColorTheme] = useState<ThemeId>('sage');
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const saved = (localStorage.getItem('color-theme') ?? 'sage') as ThemeId;
+    setColorTheme(saved);
+  }, []);
+
+  useEffect(() => {
+    if (!open) return;
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') setOpen(false);
+    }
+    document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
+  }, [open]);
+
+  function handleSelect(id: ThemeId) {
+    applyColorTheme(id);
+    setColorTheme(id);
+    setOpen(false);
+  }
+
+  return (
+    <div ref={containerRef}>
+      <button
+        onClick={() => setOpen((s) => !s)}
+        aria-expanded={open}
+        aria-label="Pick color theme"
+        className="flex w-full items-center gap-3 rounded-md px-3 py-2 text-sm text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="16"
+          height="16"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          className="shrink-0"
+        >
+          <circle cx="13.5" cy="6.5" r=".5" fill="currentColor" />
+          <circle cx="17.5" cy="10.5" r=".5" fill="currentColor" />
+          <circle cx="8.5" cy="7.5" r=".5" fill="currentColor" />
+          <circle cx="6.5" cy="12.5" r=".5" fill="currentColor" />
+          <path d="M12 2C6.5 2 2 6.5 2 12s4.5 10 10 10c.926 0 1.648-.746 1.648-1.688 0-.437-.18-.835-.437-1.125-.29-.289-.438-.652-.438-1.125a1.64 1.64 0 0 1 1.668-1.668h1.996c3.051 0 5.555-2.503 5.555-5.554C21.965 6.012 17.461 2 12 2z" />
+        </svg>
+        <span>Color theme</span>
+      </button>
+
+      {open && (
+        <div className="mx-1 mb-1 rounded-md border border-border bg-card p-2">
+          <div className="grid grid-cols-2 gap-1">
+            {THEMES.map(({ id, label, color }) => (
+              <button
+                key={id}
+                onClick={() => handleSelect(id)}
+                aria-pressed={colorTheme === id}
+                className={[
+                  'flex flex-col items-center gap-1.5 rounded-md p-2 transition-colors hover:bg-accent',
+                  colorTheme === id ? 'bg-accent' : '',
+                ].join(' ')}
+              >
+                <span
+                  style={{ backgroundColor: color }}
+                  className={[
+                    'h-7 w-7 rounded-full',
+                    colorTheme === id
+                      ? 'ring-2 ring-foreground ring-offset-1 ring-offset-card'
+                      : '',
+                  ].join(' ')}
+                />
+                <span className="text-xs text-foreground">{label}</span>
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
### Proposed Changes:

Adds a color theme picker to the navigation sidebar, letting users choose from 8 pastel color themes that apply instantly across the entire app in both light and dark mode, with the selection persisted across sessions.

### Details:

- Added 8 pastel color themes: Sage (default), Rose, Lavender, Peach, Sky, Teal, Amber, and Sand — each with full light and dark mode variable sets
- Added a "Color theme" button to the sidebar (desktop and mobile) with a palette icon, matching the style of the existing dark mode toggle
- Clicking the button expands an inline 2×4 grid card showing all 8 color swatches with labels; the active theme is highlighted with a ring indicator
- Selected theme is saved to `localStorage` and restored on load without a flash of the previous theme

### Related Issues:

- Resolves #39
